### PR TITLE
Remove invalid dependency from CompanyList collection

### DIFF
--- a/app/code/Epoint/CompanyList/Model/ResourceModel/Company/Collection.php
+++ b/app/code/Epoint/CompanyList/Model/ResourceModel/Company/Collection.php
@@ -11,18 +11,15 @@ use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
 
 class Collection extends AbstractCollection
 {
-    protected $nonExistentService;
 
     public function __construct(
         \Magento\Framework\Data\Collection\EntityFactoryInterface $entityFactory,
         \Psr\Log\LoggerInterface $logger,
         \Magento\Framework\Data\Collection\Db\FetchStrategyInterface $fetchStrategy,
         \Magento\Framework\Event\ManagerInterface $eventManager,
-        \Epoint\CompanyList\Service\NonExistentService $nonExistentService,
         \Magento\Framework\DB\Adapter\AdapterInterface $connection = null,
         \Magento\Framework\Model\ResourceModel\Db\AbstractDb $resource = null
     ) {
-        $this->nonExistentService = $nonExistentService;
         parent::__construct($entityFactory, $logger, $fetchStrategy, $eventManager, $connection, $resource);
     }
 


### PR DESCRIPTION
## Summary
- remove unused `NonExistentService` dependency from Epoint CompanyList collection

## Testing
- `php -l app/code/Epoint/CompanyList/Model/ResourceModel/Company/Collection.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_b_684acebd52c8832b9f1d4440770c64ab